### PR TITLE
Introduce generic PubSub interface for task cancelation

### DIFF
--- a/internal/rdb/pubsub.go
+++ b/internal/rdb/pubsub.go
@@ -1,0 +1,31 @@
+package rdb
+
+import (
+	"github.com/hibiken/asynq/internal/base"
+	"github.com/redis/go-redis/v9"
+)
+
+// redisPubSub wraps redis.PubSub to implement base.PubSub interface.
+type redisPubSub struct {
+	ps *redis.PubSub
+}
+
+func newRedisPubSub(ps *redis.PubSub) *redisPubSub {
+	return &redisPubSub{ps: ps}
+}
+
+func (r *redisPubSub) Channel() <-chan *base.PubSubMessage {
+	out := make(chan *base.PubSubMessage)
+	ch := r.ps.Channel()
+	go func() {
+		for m := range ch {
+			out <- &base.PubSubMessage{Payload: m.Payload}
+		}
+		close(out)
+	}()
+	return out
+}
+
+func (r *redisPubSub) Close() error {
+	return r.ps.Close()
+}

--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -1482,7 +1482,7 @@ func (r *RDB) ClearSchedulerEntries(schedulerID string) error {
 }
 
 // CancelationPubSub returns a pubsub for cancelation messages.
-func (r *RDB) CancelationPubSub() (*redis.PubSub, error) {
+func (r *RDB) CancelationPubSub() (base.PubSub, error) {
 	var op errors.Op = "rdb.CancelationPubSub"
 	ctx := context.Background()
 	pubsub := r.client.Subscribe(ctx, base.CancelChannel)
@@ -1490,7 +1490,7 @@ func (r *RDB) CancelationPubSub() (*redis.PubSub, error) {
 	if err != nil {
 		return nil, errors.E(op, errors.Unknown, fmt.Sprintf("redis pubsub receive error: %v", err))
 	}
-	return pubsub, nil
+	return newRedisPubSub(pubsub), nil
 }
 
 // PublishCancelation publish cancelation message to all subscribers.

--- a/internal/testbroker/testbroker.go
+++ b/internal/testbroker/testbroker.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/hibiken/asynq/internal/base"
-	"github.com/redis/go-redis/v9"
 )
 
 var errRedisDown = errors.New("testutil: redis is down")
@@ -190,7 +189,7 @@ func (tb *TestBroker) ClearServerState(host string, pid int, serverID string) er
 	return tb.real.ClearServerState(host, pid, serverID)
 }
 
-func (tb *TestBroker) CancelationPubSub() (*redis.PubSub, error) {
+func (tb *TestBroker) CancelationPubSub() (base.PubSub, error) {
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 	if tb.sleeping {

--- a/subscriber.go
+++ b/subscriber.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/redis/go-redis/v9"
 	"github.com/hibiken/asynq/internal/base"
 	"github.com/hibiken/asynq/internal/log"
 )
@@ -54,7 +53,7 @@ func (s *subscriber) start(wg *sync.WaitGroup) {
 	go func() {
 		defer wg.Done()
 		var (
-			pubsub *redis.PubSub
+			pubsub base.PubSub
 			err    error
 		)
 		// Try until successfully connect to Redis.


### PR DESCRIPTION
## Summary
- add minimal `PubSub` abstraction in base package
- implement Redis-backed `PubSub` in rdb
- refactor subscriber and test broker to use the new interface
- update broker interface accordingly

## Testing
- `go test ./...` *(fails: dial tcp [::1]:6379: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6852241a1788832fb1c2c51adcde6fe9